### PR TITLE
Remove 'image' when 'build' is used in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       - MYSQL_DATABASE=${DB_DATABASE}
   webapp:
     build: webapp
-    image: webapp
     environment:
       - DB_HOST=${DB_HOST}
       - DB_USER=${DB_USER}


### PR DESCRIPTION
This leads to an unintended behavior: On the first start, the image is being built by docker. On all future starts, it uses the existing image and does not rebuild it, which might be intended.